### PR TITLE
Bump C++ version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TARGET := bin/calibrator
 SRCEXT := cpp
 SOURCES := $(shell find $(SRCDIR) -type f -name "*.$(SRCEXT)")
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
-CFLAGS := -O2 -g -Wall -std=c++11 -fmessage-length=0 
+CFLAGS := -O2 -g -Wall -std=c++26 -fmessage-length=0 
 LIB := -L ~/boost/lib  -lboost_program_options -lboost_system
 INC := -I ~/boost
 


### PR DESCRIPTION
Boost now requires C++14 or newer (#5)